### PR TITLE
lcobucci/jwt 4.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ report/
 .idea/
 composer.lock
 *.swp
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "require": {
         "php": ">=7.4.0",
-        "lcobucci/jwt": "^3.2",
+        "lcobucci/jwt": "^3.4",
         "illuminate/auth": "^7.0 || ^8.0",
         "illuminate/config": "^7.0 || ^8.0",
         "illuminate/console": "^7.0 || ^8.0",
@@ -19,7 +19,10 @@
         "phpunit/phpunit": "^9.0",
         "fzaninotto/faker": "^1.8",
         "mockery/mockery": "^1.2",
-        "php-coveralls/php-coveralls": "^2.1"
+        "php-coveralls/php-coveralls": "^2.1",
+        "phpstan/phpstan": "^0.12.90",
+        "phpstan/phpstan-deprecation-rules": "^0.12.6",
+        "phpstan/extension-installer": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,14 @@
     "type": "library",
     "require": {
         "php": ">=7.4.0",
-        "lcobucci/jwt": "^3.4",
         "illuminate/auth": "^7.0 || ^8.0",
         "illuminate/config": "^7.0 || ^8.0",
         "illuminate/console": "^7.0 || ^8.0",
         "illuminate/contracts": "^7.0 || ^8.0",
         "illuminate/support": "^7.0 || ^8.0",
         "illuminate/cache": "^7.0 || ^8.0",
+        "lcobucci/jwt": "^4.0",
+        "nesbot/carbon": "^2.0",
         "vlucas/phpdotenv": "^4.0 || ^5.2"
     },
     "require-dev": {

--- a/src/Auth/JWTGuardConfig.php
+++ b/src/Auth/JWTGuardConfig.php
@@ -27,9 +27,9 @@ final class JWTGuardConfig
     /**
      * JWTGuardConfig constructor.
      *
-     * @param int  $accessTokenTtl
-     * @param int  $refreshTokenTtl
-     * @param bool $ipCheckEnabled
+     * @param int      $accessTokenTtl
+     * @param int|null $refreshTokenTtl
+     * @param bool     $ipCheckEnabled
      */
     public function __construct(int $accessTokenTtl, ?int $refreshTokenTtl, bool $ipCheckEnabled)
     {

--- a/src/Contracts/JWT.php
+++ b/src/Contracts/JWT.php
@@ -39,14 +39,14 @@ interface JWT
     public function getClaim(string $claim, bool $required = true);
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getIssuer(): string;
+    public function getIssuer(): ?string;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSubject(): string;
+    public function getSubject(): ?string;
 
     /**
      * @return \DateTimeImmutable|null
@@ -54,9 +54,9 @@ interface JWT
     public function getExpiresAt(): ?\DateTimeImmutable;
 
     /**
-     * @return \DateTimeImmutable
+     * @return \DateTimeImmutable|null
      */
-    public function getIssuedAt(): \DateTimeImmutable;
+    public function getIssuedAt(): ?\DateTimeImmutable;
 
     /**
      * @return string|null

--- a/src/Contracts/Validator.php
+++ b/src/Contracts/Validator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SPie\LaravelJWT\Contracts;
+
+use Lcobucci\JWT\Token;
+
+/**
+ * Interface Validator
+ *
+ * @package SPie\LaravelJWT\Contracts
+ */
+interface Validator
+{
+    /**
+     * @param Token $token
+     *
+     * @return bool
+     */
+    public function validate(Token $token): bool;
+}

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -55,7 +55,7 @@ final class JWT implements JWTContract
             function (Claim $claim) {
                 return $claim->getValue();
             },
-            $this->getToken()->getClaims()
+            $this->getToken()->claims()->all()
         );
     }
 
@@ -64,38 +64,24 @@ final class JWT implements JWTContract
      * @param bool   $required
      *
      * @return mixed|null
-     *
-     * @throws MissingClaimException
      */
     public function getClaim(string $claim, bool $required = true)
     {
-        try {
-            return $this->getToken()->getClaim($claim);
-        } catch (\OutOfBoundsException $e) {
-            if ($required) {
-                throw new MissingClaimException($claim);
-            }
-        }
-
-        return null;
+        return $this->getToken()->claims()->get($claim);
     }
 
     /**
-     * @return string
-     *
-     * @throws MissingClaimException
+     * @return string|null
      */
-    public function getIssuer(): string
+    public function getIssuer(): ?string
     {
         return $this->getClaim(self::CLAIM_ISSUER);
     }
 
     /**
-     * @return string
-     *
-     * @throws MissingClaimException
+     * @return string|null
      */
-    public function getSubject(): string
+    public function getSubject(): ?string
     {
         return $this->getClaim(self::CLAIM_SUBJECT);
     }
@@ -115,13 +101,16 @@ final class JWT implements JWTContract
     }
 
     /**
-     * @return \DateTimeImmutable
-     *
-     * @throws \Exception
+     * @return \DateTimeImmutable|null
      */
-    public function getIssuedAt(): \DateTimeImmutable
+    public function getIssuedAt(): ?\DateTimeImmutable
     {
-        return (new \DateTimeImmutable())->setTimestamp($this->getClaim(self::CLAIM_ISSUED_AT));
+        $issuedAt = $this->getClaim(self::CLAIM_ISSUED_AT);
+        if (empty($issuedAt)) {
+            return null;
+        }
+
+        return (new \DateTimeImmutable())->setTimestamp($issuedAt);
     }
 
     /**

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -2,10 +2,8 @@
 
 namespace SPie\LaravelJWT;
 
-use Lcobucci\JWT\Claim;
 use Lcobucci\JWT\Token;
 use SPie\LaravelJWT\Contracts\JWT as JWTContract;
-use SPie\LaravelJWT\Exceptions\MissingClaimException;
 
 /**
  * Class Token
@@ -31,19 +29,11 @@ final class JWT implements JWTContract
     }
 
     /**
-     * @return Token
-     */
-    private function getToken(): Token
-    {
-        return $this->token;
-    }
-
-    /**
      * @return string
      */
     public function getJWT(): string
     {
-        return $this->getToken();
+        return $this->token->toString();
     }
 
     /**
@@ -51,12 +41,7 @@ final class JWT implements JWTContract
      */
     public function getClaims(): array
     {
-        return \array_map(
-            function (Claim $claim) {
-                return $claim->getValue();
-            },
-            $this->getToken()->claims()->all()
-        );
+        return $this->token->claims()->all();
     }
 
     /**
@@ -67,7 +52,7 @@ final class JWT implements JWTContract
      */
     public function getClaim(string $claim, bool $required = true)
     {
-        return $this->getToken()->claims()->get($claim);
+        return $this->token->claims()->get($claim);
     }
 
     /**

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -3,6 +3,7 @@
 namespace SPie\LaravelJWT;
 
 use Lcobucci\JWT\Token;
+use Lcobucci\JWT\UnencryptedToken;
 use SPie\LaravelJWT\Contracts\JWT as JWTContract;
 
 /**
@@ -14,16 +15,16 @@ final class JWT implements JWTContract
 {
 
     /**
-     * @var Token
+     * @var UnencryptedToken
      */
-    private Token $token;
+    private UnencryptedToken $token;
 
     /**
      * Token constructor.
      *
-     * @param Token $token
+     * @param UnencryptedToken $token
      */
-    public function __construct(Token $token)
+    public function __construct(UnencryptedToken $token)
     {
         $this->token = $token;
     }

--- a/src/JWTHandler.php
+++ b/src/JWTHandler.php
@@ -2,17 +2,16 @@
 
 namespace SPie\LaravelJWT;
 
-use Lcobucci\JWT\Builder;
+use Carbon\CarbonImmutable;
+use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Parser;
-use Lcobucci\JWT\Signer;
-use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Token;
 use SPie\LaravelJWT\Contracts\JWT;
 use SPie\LaravelJWT\Contracts\JWTFactory;
 use SPie\LaravelJWT\Contracts\JWTHandler as JWTHandlerContract;
 use SPie\LaravelJWT\Contracts\Validator;
 use SPie\LaravelJWT\Exceptions\BeforeValidException;
 use SPie\LaravelJWT\Exceptions\TokenExpiredException;
-use SPie\LaravelJWT\Exceptions\InvalidSecretException;
 use SPie\LaravelJWT\Exceptions\InvalidTokenException;
 use SPie\LaravelJWT\Exceptions\InvalidSignatureException;
 
@@ -23,12 +22,6 @@ use SPie\LaravelJWT\Exceptions\InvalidSignatureException;
  */
 final class JWTHandler implements JWTHandlerContract
 {
-
-    /**
-     * @var string
-     */
-    private string $secret;
-
     /**
      * @var string
      */
@@ -40,9 +33,14 @@ final class JWTHandler implements JWTHandlerContract
     private JWTFactory $jwtFactory;
 
     /**
-     * @var Builder
+     * @var Validator
      */
-    private Builder $builder;
+    private Validator $validator;
+
+    /**
+     * @var Configuration
+     */
+    private Configuration $configuration;
 
     /**
      * @var Parser
@@ -50,56 +48,26 @@ final class JWTHandler implements JWTHandlerContract
     private Parser $parser;
 
     /**
-     * @var Signer
-     */
-    private Signer $signer;
-
-    /**
-     * @var Validator
-     */
-    private Validator $validator;
-
-    /**
      * JWTHandler constructor.
      *
-     * @param string     $secret
-     * @param string     $issuer
-     * @param JWTFactory $jwtFactory
-     * @param Builder    $builder
-     * @param Parser     $parser
-     * @param Signer     $signer
-     * @param Validator  $validator
-     *
-     * @throws InvalidSecretException
+     * @param string        $issuer
+     * @param JWTFactory    $jwtFactory
+     * @param Validator     $validator
+     * @param Configuration $configuration
+     * @param Parser        $parser
      */
     public function __construct(
-        string $secret,
         string $issuer,
         JWTFactory $jwtFactory,
-        Builder $builder,
-        Parser $parser,
-        Signer $signer,
-        Validator $validator
+        Validator $validator,
+        Configuration $configuration,
+        Parser $parser
     ) {
-        if (empty($secret)) {
-            throw new InvalidSecretException();
-        }
-
-        $this->secret = $secret;
         $this->issuer = $issuer;
         $this->jwtFactory = $jwtFactory;
-        $this->builder = $builder;
-        $this->parser = $parser;
-        $this->signer = $signer;
         $this->validator = $validator;
-    }
-
-    /**
-     * @return string
-     */
-    private function getSecret(): string
-    {
-        return $this->secret;
+        $this->configuration = $configuration;
+        $this->parser = $parser;
     }
 
     /**
@@ -119,30 +87,6 @@ final class JWTHandler implements JWTHandlerContract
     }
 
     /**
-     * @return Parser
-     */
-    private function getParser(): Parser
-    {
-        return $this->parser;
-    }
-
-    /**
-     * @return Signer
-     */
-    private function getSigner(): Signer
-    {
-        return $this->signer;
-    }
-
-    /**
-     * @return Builder
-     */
-    private function getNewBuilder(): Builder
-    {
-        return clone $this->builder;
-    }
-
-    /**
      * @param string $token
      *
      * @return JWT
@@ -155,8 +99,23 @@ final class JWTHandler implements JWTHandlerContract
      */
     public function getValidJWT(string $token): JWT
     {
+        return $this->getJWTFactory()->createJWT($this->getValidToken($token));
+    }
+
+    /**
+     * @param string $token
+     *
+     * @return Token
+     *
+     * @throws BeforeValidException
+     * @throws InvalidSignatureException
+     * @throws InvalidTokenException
+     * @throws TokenExpiredException
+     */
+    private function getValidToken(string $token): Token
+    {
         try {
-            $token = $this->getParser()->parse($token);
+            $token = $this->parser->parse($token);
         } catch (\InvalidArgumentException $e) {
             throw new InvalidTokenException();
         }
@@ -165,16 +124,16 @@ final class JWTHandler implements JWTHandlerContract
             throw new InvalidSignatureException();
         }
 
-        if ($token->isExpired()) {
+        $now = new CarbonImmutable();
+        if ($token->isExpired($now)) {
             throw new TokenExpiredException();
         }
 
-        $jwt = $this->getJWTFactory()->createJWT($token);
-        if ($jwt->getIssuedAt() > new \DateTimeImmutable()) {
+        if (!$token->hasBeenIssuedBefore($now)) {
             throw new BeforeValidException();
         }
 
-        return $jwt;
+        return $token;
     }
 
     /**
@@ -190,7 +149,7 @@ final class JWTHandler implements JWTHandlerContract
     {
         [$issuedAt, $expiresAt] = $this->createTimestamps($ttl);
 
-        $builder = $this->getNewBuilder()
+        $builder = $this->configuration->builder()
             ->issuedBy($this->getIssuer())
             ->relatedTo($subject)
             ->issuedAt($issuedAt);
@@ -204,7 +163,7 @@ final class JWTHandler implements JWTHandlerContract
         }
 
         return $this->getJWTFactory()->createJWT(
-            $builder->getToken($this->getSigner(), new Key($this->getSecret()))
+            $builder->getToken($this->configuration->signer(), $this->configuration->signingKey())
         );
     }
 
@@ -220,11 +179,9 @@ final class JWTHandler implements JWTHandlerContract
         $issuedAt = new \DateTimeImmutable();
 
         return [
-            $issuedAt->getTimestamp(),
+            $issuedAt,
             $ttl
-                ? $issuedAt
-                    ->add(new \DateInterval('PT' . $ttl . 'M'))
-                    ->getTimestamp()
+                ? $issuedAt->add(new \DateInterval('PT' . $ttl . 'M'))
                 : null
         ];
     }

--- a/src/JWTHandler.php
+++ b/src/JWTHandler.php
@@ -9,6 +9,7 @@ use Lcobucci\JWT\Signer\Key;
 use SPie\LaravelJWT\Contracts\JWT;
 use SPie\LaravelJWT\Contracts\JWTFactory;
 use SPie\LaravelJWT\Contracts\JWTHandler as JWTHandlerContract;
+use SPie\LaravelJWT\Contracts\Validator;
 use SPie\LaravelJWT\Exceptions\BeforeValidException;
 use SPie\LaravelJWT\Exceptions\TokenExpiredException;
 use SPie\LaravelJWT\Exceptions\InvalidSecretException;
@@ -54,6 +55,11 @@ final class JWTHandler implements JWTHandlerContract
     private Signer $signer;
 
     /**
+     * @var Validator
+     */
+    private Validator $validator;
+
+    /**
      * JWTHandler constructor.
      *
      * @param string     $secret
@@ -62,6 +68,7 @@ final class JWTHandler implements JWTHandlerContract
      * @param Builder    $builder
      * @param Parser     $parser
      * @param Signer     $signer
+     * @param Validator  $validator
      *
      * @throws InvalidSecretException
      */
@@ -71,7 +78,8 @@ final class JWTHandler implements JWTHandlerContract
         JWTFactory $jwtFactory,
         Builder $builder,
         Parser $parser,
-        Signer $signer
+        Signer $signer,
+        Validator $validator
     ) {
         if (empty($secret)) {
             throw new InvalidSecretException();
@@ -83,6 +91,7 @@ final class JWTHandler implements JWTHandlerContract
         $this->builder = $builder;
         $this->parser = $parser;
         $this->signer = $signer;
+        $this->validator = $validator;
     }
 
     /**
@@ -152,7 +161,7 @@ final class JWTHandler implements JWTHandlerContract
             throw new InvalidTokenException();
         }
 
-        if (!$token->verify($this->getSigner(), $this->getSecret())) {
+        if (!$this->validator->validate($token)) {
             throw new InvalidSignatureException();
         }
 

--- a/src/Providers/Registrar.php
+++ b/src/Providers/Registrar.php
@@ -6,6 +6,11 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validator as LcobucciValidatorContract;
+use Lcobucci\JWT\Validation\Validator as LcobucciValidator;
 use SPie\LaravelJWT\Auth\JWTGuard;
 use SPie\LaravelJWT\Auth\JWTGuardConfig;
 use SPie\LaravelJWT\Contracts\EventFactory as EventFactoryContract;
@@ -15,10 +20,12 @@ use SPie\LaravelJWT\Contracts\JWTHandler as JWTHandlerContract;
 use SPie\LaravelJWT\Contracts\Registrar as RegistrarContract;
 use SPie\LaravelJWT\Contracts\TokenBlockList;
 use SPie\LaravelJWT\Contracts\TokenProvider;
+use SPie\LaravelJWT\Contracts\Validator as ValidatorContract;
 use SPie\LaravelJWT\Events\EventFactory;
 use SPie\LaravelJWT\Exceptions\InvalidTokenProviderKeyException;
 use SPie\LaravelJWT\JWTFactory;
 use SPie\LaravelJWT\JWTHandler;
+use SPie\LaravelJWT\Validator;
 
 /**
  * Class Registrar
@@ -74,7 +81,12 @@ final class Registrar implements RegistrarContract
             ->registerJWTHandler()
             ->registerTokenBlockList()
             ->registerJWTGuardConfig()
-            ->registerEventFactory();
+            ->registerEventFactory()
+            ->registerValidator()
+            ->registerSigner()
+            ->registerSecretKey()
+            ->registerSignedWithConstraint()
+            ->registerValidator();
     }
 
     /**
@@ -108,21 +120,72 @@ final class Registrar implements RegistrarContract
     /**
      * @return $this
      */
+    private function registerSignedWithConstraint(): self
+    {
+        $this->app->singleton(SignedWith::class, fn () => new SignedWith(
+            $this->app->get(Signer::class),
+            $this->app->get(Key::class)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    private function registerValidator(): self
+    {
+        $this->app->singleton(LcobucciValidatorContract::class, LcobucciValidator::class);
+
+        $this->getApp()->singleton(ValidatorContract::class, fn () => new Validator(
+            $this->app->get(LcobucciValidatorContract::class),
+            $this->app->get(SignedWith::class)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    private function registerSigner(): self
+    {
+        $this->app->singleton(Signer::class, function () {
+            $signerClass = $this->getSignerSetting();
+
+            return new $signerClass();
+        });
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    private function registerSecretKey(): self
+    {
+        $this->app->singleton(Key::class, fn () => new Key($this->getSecretSetting()));
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     private function registerJWTHandler(): self
     {
         $this->getApp()->bind(Builder::class);
         $this->getApp()->bind(Parser::class);
 
         $this->getApp()->singleton(JWTHandlerContract::class, function () {
-            $signerClass = $this->getSignerSetting();
-
             return new JWTHandler(
                 $this->getSecretSetting(),
                 $this->getIssuerSetting(),
                 $this->getApp()->get(JWTFactoryContract::class),
                 $this->getApp()->get(Builder::class),
                 $this->getApp()->get(Parser::class),
-                new $signerClass()
+                $this->app->get(Signer::class),
+                $this->getApp()->get(ValidatorContract::class)
             );
         });
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SPie\LaravelJWT;
+
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint;
+use Lcobucci\JWT\Validator as LcobucciValidator;
+use SPie\LaravelJWT\Contracts\Validator as ValidatorContract;
+
+/**
+ * Class Validator
+ *
+ * @package SPie\LaravelJWT
+ */
+final class Validator implements ValidatorContract
+{
+    /**
+     * @var LcobucciValidator
+     */
+    private LcobucciValidator $validator;
+
+    /**
+     * @var Constraint
+     */
+    private Constraint $constraint;
+
+    /**
+     * Validator constructor.
+     *
+     * @param LcobucciValidator $validator
+     * @param Constraint        $constraint
+     */
+    public function __construct(LcobucciValidator $validator, Constraint $constraint)
+    {
+        $this->validator = $validator;
+        $this->constraint = $constraint;
+    }
+
+    /**
+     * @param Token $token
+     *
+     * @return bool
+     */
+    public function validate(Token $token): bool
+    {
+        return $this->validator->validate($token, $this->constraint);
+    }
+}

--- a/tests/JWTHelper.php
+++ b/tests/JWTHelper.php
@@ -8,9 +8,14 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\DataSet;
+use Lcobucci\JWT\Token\Plain;
+use Lcobucci\JWT\Token\Signature;
 use Mockery;
 use Mockery\MockInterface;
 use SPie\LaravelJWT\Auth\JWTGuardConfig;
@@ -188,6 +193,22 @@ trait JWTHelper
     }
 
     /**
+     * @param DataSet|null   $headers
+     * @param DataSet|null   $claims
+     * @param Signature|null $signature
+     *
+     * @return Plain
+     */
+    private function createPlainToken(DataSet $headers = null, DataSet $claims = null, Signature $signature = null): Plain
+    {
+        return new Plain(
+            $headers ?: $this->createDataSet(),
+            $claims ?: $this->createDataSet(),
+            $signature ?: $this->createSignature()
+        );
+    }
+
+    /**
      * @return Signer
      */
     protected function getSigner(): Signer
@@ -200,7 +221,7 @@ trait JWTHelper
      *
      * @return Builder|MockInterface
      */
-    protected function createBuilder(Token $token = null): Builder
+    protected function createBuilder(): Builder
     {
         $builder = Mockery::spy(Builder::class);
 
@@ -219,31 +240,57 @@ trait JWTHelper
             ->getMock()
             ->shouldReceive('withClaim')
             ->andReturn($builder)
-            ->getMock()
-            ->shouldReceive('getToken')
-            ->andReturn($token ?: $this->createToken())
             ->getMock();
     }
 
     /**
-     * @param Token|\Exception|null $token
+     * @param Builder|MockInterface $builder
+     * @param Token                 $token
+     * @param Signer                $signer
+     * @param Key                   $key
      *
+     * @return $this
+     */
+    private function mockBuilderGetToken(MockInterface $builder, Token $token, Signer $signer, Key $key): self
+    {
+        $builder
+            ->shouldReceive('getToken')
+            ->with($signer, $key)
+            ->andReturn($token);
+
+        return $this;
+    }
+
+    /**
      * @return Parser|MockInterface
      */
-    protected function createParser($token = null): Parser
+    protected function createParser(): Parser
     {
-        $parser = Mockery::spy(Parser::class);
+        return Mockery::spy(Parser::class);
+    }
 
-        $parseExpectation = $parser->shouldReceive('parse');
+    /**
+     * @param MockInterface $parser
+     * @param Token         $token
+     * @param string        $jwt
+     *
+     * @return $this
+     */
+    private function mockParserParse(MockInterface $parser, $token, string $jwt): self
+    {
+        $expectation = $parser
+            ->shouldReceive('parse')
+            ->with($jwt);
+
         if ($token instanceof \Exception) {
-            $parseExpectation->andThrow($token);
+            $expectation->andThrow($token);
 
-            return $parser;
+            return $this;
         }
 
-        $parseExpectation->andReturn($token ?: $this->createToken());
+        $expectation->andReturn($token);
 
-        return $parser;
+        return $this;
     }
 
     /**
@@ -301,16 +348,28 @@ trait JWTHelper
     }
 
     /**
-     * @param JWT|null $jwt
-     *
      * @return JWTFactory|MockInterface
      */
-    protected function createJWTFactory(JWT $jwt = null): JWTFactory
+    protected function createJWTFactory(): JWTFactory
     {
-        return Mockery::spy(JWTFactory::class)
+        return Mockery::spy(JWTFactory::class);
+    }
+
+    /**
+     * @param JWTFactory|MockInterface $jwtFactory
+     * @param JWT                      $jwt
+     * @param Token                    $token
+     *
+     * @return $this
+     */
+    private function mockJWTFactoryCreateJWT(MockInterface $jwtFactory, JWT $jwt, Token $token): self
+    {
+        $jwtFactory
             ->shouldReceive('createJWT')
-            ->andReturn($jwt ?: $this->createJWT())
-            ->getMock();
+            ->with($token)
+            ->andReturn($jwt);
+
+        return $this;
     }
 
     /**
@@ -490,5 +549,49 @@ trait JWTHelper
             ->andReturn($valid);
 
         return $this;
+    }
+
+    /**
+     * @return Key|MockInterface
+     */
+    private function createKey(): Key
+    {
+        return Mockery::spy(Key::class);
+    }
+
+    /**
+     * @param array  $data
+     * @param string $encoded
+     *
+     * @return DataSet
+     */
+    private function createDataSet(array $data = [], string $encoded = ''): DataSet
+    {
+        return new DataSet($data, $encoded);
+    }
+
+    /**
+     * @param string|null $hash
+     * @param string|null $encoded
+     *
+     * @return Signature
+     */
+    private function createSignature(string $hash = null, string $encoded = null): Signature
+    {
+        return new Signature($hash ?: $this->getFaker()->sha256, $encoded ?: $this->getFaker()->sha256);
+    }
+
+    /**
+     * @param Signer|null $signer
+     * @param Key|null    $key
+     *
+     * @return Configuration|MockInterface
+     */
+    private function createConfiguration(Signer $signer = null, Key $key = null): Configuration
+    {
+        return Configuration::forSymmetricSigner(
+            $signer ?: $this->createSigner(),
+            $key ?: $this->createKey()
+        );
     }
 }

--- a/tests/JWTHelper.php
+++ b/tests/JWTHelper.php
@@ -21,6 +21,7 @@ use SPie\LaravelJWT\Contracts\RefreshTokenRepository;
 use SPie\LaravelJWT\Contracts\JWT;
 use SPie\LaravelJWT\Contracts\JWTHandler;
 use SPie\LaravelJWT\Contracts\TokenProvider;
+use SPie\LaravelJWT\Contracts\Validator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -462,6 +463,31 @@ trait JWTHelper
             ->shouldReceive('getRequestToken')
             ->with($request)
             ->andReturn($token);
+
+        return $this;
+    }
+
+    /**
+     * @return Validator|MockInterface
+     */
+    private function createValidator(): Validator
+    {
+        return Mockery::spy(Validator::class);
+    }
+
+    /**
+     * @param Validator|MockInterface $validator
+     * @param bool                    $valid
+     * @param Token                   $token
+     *
+     * @return $this
+     */
+    private function mockValidatorValidate(MockInterface $validator, bool $valid, Token $token): self
+    {
+        $validator
+            ->shouldReceive('validate')
+            ->with($token)
+            ->andReturn($valid);
 
         return $this;
     }

--- a/tests/JWTHelper.php
+++ b/tests/JWTHelper.php
@@ -16,6 +16,7 @@ use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Token\DataSet;
 use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\Token\Signature;
+use Lcobucci\JWT\UnencryptedToken;
 use Mockery;
 use Mockery\MockInterface;
 use SPie\LaravelJWT\Auth\JWTGuardConfig;
@@ -189,7 +190,7 @@ trait JWTHelper
      */
     protected function createToken(): Token
     {
-        return Mockery::spy(Token::class);
+        return Mockery::spy(UnencryptedToken::class);
     }
 
     /**

--- a/tests/Unit/JWTHandlerTest.php
+++ b/tests/Unit/JWTHandlerTest.php
@@ -66,7 +66,6 @@ final class JWTHandlerTest extends TestCase
      */
     private function setUpCreateJWTTest(): array
     {
-
         $jwt = $this->createJWT();
         $token = $this->createPlainToken();
         $jwtFactory = $this->createJWTFactory();

--- a/tests/Unit/JWTTest.php
+++ b/tests/Unit/JWTTest.php
@@ -4,6 +4,7 @@ namespace SPie\LaravelJWT\Test\Unit;
 
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Token\DataSet;
+use Lcobucci\JWT\UnencryptedToken;
 use Mockery;
 use Mockery\MockInterface;
 use OutOfBoundsException;
@@ -172,14 +173,14 @@ final class JWTTest extends TestCase
 
     /**
      * @param mixed|null $claim
-     * @param Claim[]    $claims
+     * @param array      $claims
      *
      * @return Token|MockInterface
      */
     private function createJWTToken($claim = null, array $claims = []): Token
     {
         $dataSet = new DataSet($claims, $this->getFaker()->sha256);
-        $token = Mockery::spy(Token::class);
+        $token = Mockery::spy(UnencryptedToken::class);
         $token
             ->shouldReceive('claims')
             ->andReturn($dataSet);

--- a/tests/Unit/JWTTest.php
+++ b/tests/Unit/JWTTest.php
@@ -2,7 +2,6 @@
 
 namespace SPie\LaravelJWT\Test\Unit;
 
-use Lcobucci\JWT\Claim;
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Token\DataSet;
 use Mockery;
@@ -29,10 +28,10 @@ final class JWTTest extends TestCase
      */
     public function testGetJWT(): void
     {
-        $jwt = $this->getFaker()->uuid;
+        $jwt = $this->getFaker()->sha256;
         $token = $this->createJWTToken();
         $token
-            ->shouldReceive('__toString')
+            ->shouldReceive('toString')
             ->andReturn($jwt);
 
         $this->assertEquals($jwt, $this->createJWT($token)->getJWT());
@@ -117,19 +116,10 @@ final class JWTTest extends TestCase
      */
     public function testGetClaims(): void
     {
-        $claim = Mockery::mock(Claim::class);
-        $claim
-            ->shouldReceive('getValue')
-            ->andReturn($this->getFaker()->uuid);
+        $claims = [$this->getFaker()->word => $this->getFaker()->word];
+        $token = $this->createJWTToken(null, $claims);
 
-        $token = $this->createJWTToken(null, [$claim]);
-
-        $this->assertEquals(
-            [
-                $claim->getValue()
-            ],
-            $this->createJWT($token)->getClaims()
-        );
+        $this->assertEquals($claims, $this->createJWT($token)->getClaims());
     }
 
     /**

--- a/tests/Unit/JWTTest.php
+++ b/tests/Unit/JWTTest.php
@@ -4,6 +4,7 @@ namespace SPie\LaravelJWT\Test\Unit;
 
 use Lcobucci\JWT\Claim;
 use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Token\DataSet;
 use Mockery;
 use Mockery\MockInterface;
 use OutOfBoundsException;
@@ -43,13 +44,8 @@ final class JWTTest extends TestCase
     public function testGetIssuer(): void
     {
         $issuer = $this->getFaker()->uuid;
-        $token = $this->createJWTToken($issuer);
 
-        $this->assertEquals($issuer, $this->createJWT($token)->getIssuer());
-        $token
-            ->shouldHaveReceived('getClaim')
-            ->with('iss')
-            ->once();
+        $this->assertEquals($issuer, $this->createJWT($this->createJWTToken(null, ['iss' => $issuer]))->getIssuer());
     }
 
     /**
@@ -59,9 +55,7 @@ final class JWTTest extends TestCase
      */
     public function testGetIssuerEmpty(): void
     {
-        $this->expectException(MissingClaimException::class);
-
-        $this->createJWT($this->createJWTToken(new OutOfBoundsException()))->getIssuer();
+        $this->assertNull($this->createJWT($this->createJWTToken())->getIssuer());
     }
 
     /**
@@ -70,25 +64,16 @@ final class JWTTest extends TestCase
     public function testGetSubject(): void
     {
         $subject = $this->getFaker()->uuid;
-        $token = $this->createJWTToken($subject);
 
-        $this->assertEquals($subject, $this->createJWT($token)->getSubject());
-        $token
-            ->shouldHaveReceived('getClaim')
-            ->with('sub')
-            ->once();
+        $this->assertEquals($subject, $this->createJWT($this->createJWTToken(null, ['sub' => $subject]))->getSubject());
     }
 
     /**
      * @return void
-     *
-     * @throws MissingClaimException
      */
     public function testGetSubjectEmpty(): void
     {
-        $this->expectException(MissingClaimException::class);
-
-        $this->createJWT($this->createJWTToken(new OutOfBoundsException()))->getSubject();
+        $this->assertNull($this->createJWT($this->createJWTToken())->getSubject());
     }
 
     /**
@@ -97,13 +82,8 @@ final class JWTTest extends TestCase
     public function testGetIssuedAt(): void
     {
         $issuedAt = new \DateTimeImmutable($this->getFaker()->dateTime()->format('Y-m-d H:i:s'));
-        $token = $this->createJWTToken($issuedAt->getTimestamp());
 
-        $this->assertEquals($issuedAt, $this->createJWT($token)->getIssuedAt());
-        $token
-            ->shouldHaveReceived('getClaim')
-            ->with('iat')
-            ->once();
+        $this->assertEquals($issuedAt, $this->createJWT($this->createJWTToken(null, ['iat' => $issuedAt->getTimestamp()]))->getIssuedAt());
     }
 
     /**
@@ -111,9 +91,7 @@ final class JWTTest extends TestCase
      */
     public function testGetIssuedAtEmpty(): void
     {
-        $this->expectException(MissingClaimException::class);
-
-        $this->createJWT($this->createJWTToken(new OutOfBoundsException()))->getIssuedAt();
+        $this->assertNull($this->createJWT($this->createJWTToken())->getIssuedAt());
     }
 
     /**
@@ -122,13 +100,8 @@ final class JWTTest extends TestCase
     public function testGetExpiresAt(): void
     {
         $expiresAt = new \DateTimeImmutable($this->getFaker()->dateTime()->format('Y-m-d H:i:s'));
-        $token = $this->createJWTToken($expiresAt->getTimestamp());
 
-        $this->assertEquals($expiresAt, $this->createJWT($token)->getExpiresAt());
-        $token
-            ->shouldHaveReceived('getClaim')
-            ->with('exp')
-            ->once();
+        $this->assertEquals($expiresAt, $this->createJWT($this->createJWTToken(null, ['exp' => $expiresAt->getTimestamp()]))->getExpiresAt());
     }
 
     /**
@@ -165,13 +138,8 @@ final class JWTTest extends TestCase
     public function testGetRefreshTokenId(): void
     {
         $refreshTokenId = $this->getFaker()->uuid;
-        $token = $this->createJWTToken($refreshTokenId);
 
-        $this->assertEquals($refreshTokenId, $this->createJWT($token)->getRefreshTokenId());
-        $token
-            ->shouldHaveReceived('getClaim')
-            ->with('rti')
-            ->once();
+        $this->assertEquals($refreshTokenId, $this->createJWT($this->createJWTToken(null, ['rti' => $refreshTokenId]))->getRefreshTokenId());
     }
 
     /**
@@ -188,13 +156,8 @@ final class JWTTest extends TestCase
     public function testGetIpAddress(): void
     {
         $ipAddress = $this->getFaker()->ipv4;
-        $token = $this->createJWTToken($ipAddress);
 
-        $this->assertEquals($ipAddress, $this->createJWT($token)->getIpAddress());
-        $token
-            ->shouldHaveReceived('getClaim')
-            ->with('ipa')
-            ->once();
+        $this->assertEquals($ipAddress, $this->createJWT($this->createJWTToken(null, ['ipa' => $ipAddress]))->getIpAddress());
     }
 
     /**
@@ -225,10 +188,11 @@ final class JWTTest extends TestCase
      */
     private function createJWTToken($claim = null, array $claims = []): Token
     {
+        $dataSet = new DataSet($claims, $this->getFaker()->sha256);
         $token = Mockery::spy(Token::class);
         $token
-            ->shouldReceive('getClaims')
-            ->andReturn($claims);
+            ->shouldReceive('claims')
+            ->andReturn($dataSet);
 
         $getClaimExpectation = $token->shouldReceive('getClaim');
         if ($claim instanceof \Exception) {

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace SPie\LaravelJWT\Test\Unit;
+
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validator as LcobucciValidator;
+use Lcobucci\JWT\Validation\Constraint;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use SPie\LaravelJWT\Test\JWTHelper;
+use SPie\LaravelJWT\Validator;
+
+/**
+ * Class ValidatorTest
+ *
+ * @package SPie\LaravelJWT\Test\Unit
+ */
+final class ValidatorTest extends TestCase
+{
+    use JWTHelper;
+
+    //region Tests
+
+    /**
+     * @return void
+     */
+    public function testValidateWithValidToken(): void
+    {
+        $token = $this->createToken();
+        $constraint = $this->createContraint();
+        $lcobucciValidator = $this->createLcobucciValidator();
+        $this->mockLcobucciValidatorValidate($lcobucciValidator, true, $token, $constraint);
+
+        $this->assertTrue($this->getValidator($lcobucciValidator, $constraint)->validate($token));
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateWithoutValidToken(): void
+    {
+        $token = $this->createToken();
+        $constraint = $this->createContraint();
+        $lcobucciValidator = $this->createLcobucciValidator();
+        $this->mockLcobucciValidatorValidate($lcobucciValidator, false, $token, $constraint);
+
+        $this->assertFalse($this->getValidator($lcobucciValidator, $constraint)->validate($token));
+    }
+
+    //endregion
+
+    /**
+     * @param LcobucciValidator|null $validator
+     * @param Constraint|null        $constraint
+     *
+     * @return Validator
+     */
+    private function getValidator(LcobucciValidator $validator = null, Constraint $constraint = null): Validator
+    {
+        return new Validator(
+            $validator ?: $this->createLcobucciValidator(),
+            $constraint ?: $this->createContraint()
+        );
+    }
+
+    /**
+     * @return LcobucciValidator|MockInterface
+     */
+    private function createLcobucciValidator(): LcobucciValidator
+    {
+        return m::spy(LcobucciValidator::class);
+    }
+
+    /**
+     * @param LcobucciValidator|MockInterface $validator
+     * @param bool                            $valid
+     * @param Token                           $token
+     * @param Constraint                      $constraint
+     *
+     * @return $this
+     */
+    private function mockLcobucciValidatorValidate(
+        MockInterface $validator,
+        bool $valid,
+        Token $token,
+        Constraint $constraint
+    ): self {
+        $validator
+            ->shouldReceive('validate')
+            ->with($token, $constraint)
+            ->andReturn($valid);
+
+        return $this;
+    }
+
+    /**
+     * @return Constraint|MockInterface
+     */
+    private function createContraint(): Constraint
+    {
+        return m::spy(Constraint::class);
+    }
+}


### PR DESCRIPTION
Upgrade `lcobucci/jwt` to 4.0 and using the new features.
`JWT` doesn't use `Claim` anymore but `DataSet` object instead.
`JWTHandler` requires `Configuration` instead of `Builder`, and `Signer` and registers a `Key` object instead of using the secret directly.
Requires `nesbot/carbon` ^2.0 for testability.